### PR TITLE
Apache license spdx conformity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,4 +87,4 @@ Related projects
 License
 #######
 
-Copyright (c) 2017-2022, Artur Maciag, All rights reserved. Apache v2
+Copyright (c) 2017-2022, Artur Maciag, All rights reserved. Apache-2.0

--- a/jsonschema_spec/__init__.py
+++ b/jsonschema_spec/__init__.py
@@ -5,6 +5,6 @@ __author__ = "Artur Maciag"
 __email__ = "maciag.artur@gmail.com"
 __version__ = "0.1.2"
 __url__ = "https://github.com/p1c2u/jsonschema-spec"
-__license__ = "Apache License, Version 2.0"
+__license__ = "Apache-2.0"
 
 __all__ = ["Spec", "default_handlers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "jsonschema-spec"
 version = "0.1.2"
 description = "JSONSchema Spec with object-oriented paths"
 authors = ["Artur Maciag <maciag.artur@gmail.com>"]
-license = "Apache License, Version 2.0"
+license = "Apache-2.0"
 readme = "README.rst"
 repository = "https://github.com/p1c2u/jsonschema-spec"
 keywords = ["jsonschema", "swagger", "spec"]
@@ -36,7 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Topic :: Software Development :: Libraries"
+    "Topic :: Software Development :: Libraries",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Pypi lists the license of jsonschema-spec currently as "License: Other/Proprietary License (Apache License, Version 2.0" 
This is my first try to let pypi recognize that this is in fact the one and only Apache-2.0 not some "Other/Proprietary License"
