### PR TITLE
jsonschema 4.17 dependency limit

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -542,7 +542,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.0"
-content-hash = "e863de287e24a1ff7dacf8dd3a212fc50a310bfb836b0ff241d2c9d816171220"
+content-hash = "8ffcd04c9d2c3c4f39af012fef4da7d12c990e1b161bc93d48b16794972ac319"
 
 [metadata.files]
 astor = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-jsonschema = "^4.0.0"
+jsonschema = ">=4.0.0,<4.18.0"
 pathable = "^0.4.1"
 python = "^3.7.0"
 PyYAML = ">=5.1"


### PR DESCRIPTION
Relates to https://github.com/python-openapi/openapi-spec-validator/issues/201 and https://github.com/python-openapi/openapi-schema-validator/issues/70